### PR TITLE
Hotfix: Correct Python import paths in main.py

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,9 +4,9 @@ from pydantic import BaseModel
 from typing import List, Optional
 from sqlmodel import Session, select
 
-from backend.database import create_db_and_tables, get_session
-from backend.models import Product, Sale, SaleItem # Import SaleItem
-from backend import promptpay_utils
+from database import create_db_and_tables, get_session
+from models import Product, Sale, SaleItem # Import SaleItem
+import promptpay_utils
 
 # Create the FastAPI app
 app = FastAPI(


### PR DESCRIPTION
I adjusted the import statements in `backend/main.py` to be relative to the Docker container's working directory. This resolves a `ModuleNotFoundError` that occurs when the application is run within Docker.

Changes:
- `from backend.database import ...` -> `from database import ...`
- `from backend.models import ...` -> `from models import ...`
- `from backend import promptpay_utils` -> `import promptpay_utils`